### PR TITLE
fix: Correctly compare strings with common prefix

### DIFF
--- a/source/libs/strings.c
+++ b/source/libs/strings.c
@@ -73,5 +73,5 @@ int stricmp(const string a, const string b)
     unsigned char bc = lower(b.s[i]);
 
     // 0 if equal, -1 if a is lesser, 1 if b is lesser
-    return i == n ? ac != bc : ac < bc ? -1 : 1;
+    return ac == bc ? 0 : ac < bc ? -1 : 1;
 }


### PR DESCRIPTION
This fixes the `stricmp` function defined in the custom strings library, which was failing when encountering two string with a common prefix:

```
stricmp("ab", "cd") = -1
stricmp("cd", "ab") =  1 (correct)

stricmp("ab", "abcd") = 1
stricmp("abcd", "ab") = 1 (incorrect)
```

With the fixed behavior:

```
stricmp("ab", "cd") = -1
stricmp("cd", "ab") =  1 (correct)

stricmp("ab", "abcd") = -1
stricmp("abcd", "ab") =  1 (correct)
```

This bug was leading to the list of files being incorrectly sorted before sealing the FNTB section, which in turn led to duplicate directories in the generated FNTB section of the final ROM.

This fix has been tested for both Pokémon Platinum (US) and Pokémon Ranger: Shadows of Almia (US), and both produce matching ROMs. This fix has been tested on aarch64 macOS and amd64 Ubuntu hosts.