### PR TITLE
Add nef field for arm7

### DIFF
--- a/include/libs/strings.h
+++ b/include/libs/strings.h
@@ -18,12 +18,14 @@ typedef struct {
     string tail;
 } strpair;
 
+#define lengthof(__s) ((long)sizeof(__s) / (long)sizeof(*(__s)) - 1)
+
 // clang-format off
 // constructor macros
 #define string(...)           stringX(__VA_ARGS__, stringL, stringS)(__VA_ARGS__)
 #define stringX(a, b, c, ...) c
 #define stringZ               (string){ .s = 0,   .len = 0 }
-#define stringS(__s)          (string){ .s = (unsigned char *)(__s), .len = sizeof(__s) / sizeof(*(__s)) - 1 }
+#define stringS(__s)          (string){ .s = (unsigned char *)(__s), .len = lengthof(__s) }
 #define stringL(__s, __len)   (string){ .s = (unsigned char *)(__s), .len = (__len) }
 
 // unpacking macro for use by printf-esque functions

--- a/source/libs/fileio.c
+++ b/source/libs/fileio.c
@@ -16,11 +16,11 @@ static inline long priv_fsize(FILE *infp)
     return fsize;
 }
 
-#define wrapsfn(__cfn)                                                           \
-    {                                                                            \
-        char cfilename[256] = { 0 };                                             \
-        memcpy(cfilename, filename.s, filename.len <= 255 ? filename.len : 255); \
-        return __cfn(cfilename);                                                 \
+#define wrapsfn(__cfn)                                                             \
+    {                                                                              \
+        char cfilename[4096] = { 0 };                                              \
+        memcpy(cfilename, filename.s, filename.len <= 4095 ? filename.len : 4095); \
+        return __cfn(cfilename);                                                   \
     }
 
 string fload(const char *filename)

--- a/source/libs/fileio.c
+++ b/source/libs/fileio.c
@@ -17,11 +17,11 @@ static inline long priv_fsize(FILE *infp)
 }
 
 #define wrapsfn(__cfn)                                                             \
-    {                                                                              \
+    do {                                                                           \
         char cfilename[4096] = { 0 };                                              \
         memcpy(cfilename, filename.s, filename.len <= 4095 ? filename.len : 4095); \
         return __cfn(cfilename);                                                   \
-    }
+    } while (0)
 
 string fload(const char *filename)
 {

--- a/source/parse/cfg_arm.c
+++ b/source/parse/cfg_arm.c
@@ -160,7 +160,7 @@ static cfgresult cfg_arm7_nef(rompacker *packer, string val, long line)
     varsub(val, packer);
 
     if (val.len < 4) configerr("nef path length is less than four characters");
-    else if (memcmp(val.s + val.len - sizeof(".nef") + 1, ".nef", 4) != 0)
+    else if (memcmp(val.s + val.len - sizeof(".nef") + 1, ".nef", sizeof(".nef") - 1) != 0)
         configerr("nef path does not end in .nef");
 
     long len = val.len - ((long)sizeof(".nef") - 1);

--- a/source/parse/cfg_arm.c
+++ b/source/parse/cfg_arm.c
@@ -160,24 +160,26 @@ static cfgresult cfg_arm7_nef(rompacker *packer, string val, long line)
     varsub(val, packer);
 
     if (val.len < 4) configerr("nef path length is less than four characters");
-    else if (strncmp((char *)val.s + val.len - 4, ".nef", 4) != 0)
+    else if (memcmp(val.s + val.len - sizeof(".nef") + 1, ".nef", 4) != 0)
         configerr("nef path does not end in .nef");
 
+    long len = val.len - ((long)sizeof(".nef") - 1);
+
     string buf = {
-        .s   = malloc(val.len - 4 + sizeof("_defs.sbin") + 1 + 1),
-        .len = val.len - 4 + (long)sizeof(".sbin"),
+        .s   = malloc(len + sizeof("_defs.sbin") - 1),
+        .len = len + (long)sizeof(".sbin") - 1,
     };
 
     memcpy(buf.s, val.s, val.len - 4);
-    memcpy((char *)buf.s + val.len - 4, ".sbin", sizeof(".sbin"));
+    memcpy(buf.s + len, ".sbin", sizeof(".sbin") - 1);
 
     cfgresult res = cfg_arm7_staticbinary(packer, buf, line);
     if (res.code != 0) { goto error; }
 
     // in case it clobbers the buffer, copy again.
-    memcpy(buf.s, val.s, val.len - 4);
-    memcpy((char *)buf.s + val.len - 4, "_defs.sbin", sizeof("_defs.sbin"));
-    buf.len = val.len - 4 + (long)sizeof("_defs.sbin");
+    memcpy(buf.s, val.s, val.len);
+    memcpy(buf.s + len, "_defs.sbin", sizeof("_defs.sbin") - 1);
+    buf.len = len + (long)sizeof("_defs.sbin") - 1;
 
     res = cfg_arm7_definitions(packer, buf, line);
 

--- a/source/parse/cfg_arm.c
+++ b/source/parse/cfg_arm.c
@@ -16,7 +16,7 @@
 #include "libs/strings.h"
 #include "libs/vector.h"
 
-#define NEF_EXT_LEN ((long)sizeof(".nef") - 1)
+#define NEF_EXT_LEN lengthof(".nef")
 
 // NOTE: This performs an allocation that may *appear* to be left dangling, but we employ a trick:
 // The first element of the vector points to the beginning of the allocated region, so freeing the
@@ -130,29 +130,37 @@ static cfgresult cfg_arm9_nef(rompacker *packer, string val, long line)
     varsub(val, packer);
 
     if (val.len < NEF_EXT_LEN) configerr("nef path length is less than four characters");
+
     const string stem = { .s = val.s + val.len - NEF_EXT_LEN, .len = NEF_EXT_LEN };
     if (!strequ(stem, string(".nef"))) configerr("nef path does not end in .nef");
 
     long len = val.len - NEF_EXT_LEN;
 
-    string buf = string(malloc(len + sizeof("_defs.sbin") - 1), len + (long)sizeof(".sbin") - 1);
+    {
+        string buf = string(malloc(len + lengthof(".sbin")), len + lengthof(".sbin"));
 
-    memcpy(buf.s, val.s, len);
-    memcpy(buf.s + len, ".sbin", sizeof(".sbin") - 1);
+        memcpy(buf.s, val.s, len);
+        memcpy(buf.s + len, ".sbin", lengthof(".sbin"));
 
-    cfgresult res = cfg_arm9_staticbinary(packer, buf, line);
-    if (res.code != 0) { goto error; }
+        cfgresult res = cfg_arm9_staticbinary(packer, buf, line);
+        free(buf.s);
 
-    // in case it clobbers the buffer, copy again.
-    memcpy(buf.s, val.s, len);
-    memcpy(buf.s + len, "_defs.sbin", sizeof("_defs.sbin") - 1);
-    buf.len = len + (long)sizeof("_defs.sbin") - 1;
+        if (res.code != 0) return res;
+    }
 
-    res = cfg_arm9_definitions(packer, buf, line);
+    {
+        string buf = string(malloc(len + lengthof("_defs.sbin")), len + lengthof("_defs.sbin"));
 
-error:
-    free(buf.s);
-    return res;
+        memcpy(buf.s, val.s, len);
+        memcpy(buf.s + len, "_defs.sbin", lengthof("_defs.sbin"));
+
+        cfgresult res = cfg_arm9_definitions(packer, buf, line);
+        free(buf.s);
+
+        if (res.code != 0) return res;
+    }
+
+    return configok;
 }
 
 static cfgresult cfg_arm7_staticbinary(rompacker *packer, string val, long line)
@@ -192,29 +200,37 @@ static cfgresult cfg_arm7_nef(rompacker *packer, string val, long line)
     varsub(val, packer);
 
     if (val.len < NEF_EXT_LEN) configerr("nef path length is less than four characters");
+
     const string stem = { .s = val.s + val.len - NEF_EXT_LEN, .len = NEF_EXT_LEN };
     if (!strequ(stem, string(".nef"))) configerr("nef path does not end in .nef");
 
     long len = val.len - NEF_EXT_LEN;
 
-    string buf = string(malloc(len + sizeof("_defs.sbin") - 1), len + (long)sizeof(".sbin") - 1);
+    {
+        string buf = string(malloc(len + lengthof(".sbin")), len + lengthof(".sbin"));
 
-    memcpy(buf.s, val.s, len);
-    memcpy(buf.s + len, ".sbin", sizeof(".sbin") - 1);
+        memcpy(buf.s, val.s, len);
+        memcpy(buf.s + len, ".sbin", lengthof(".sbin"));
 
-    cfgresult res = cfg_arm7_staticbinary(packer, buf, line);
-    if (res.code != 0) { goto error; }
+        cfgresult res = cfg_arm7_staticbinary(packer, buf, line);
+        free(buf.s);
 
-    // in case it clobbers the buffer, copy again.
-    memcpy(buf.s, val.s, len);
-    memcpy(buf.s + len, "_defs.sbin", sizeof("_defs.sbin") - 1);
-    buf.len = len + (long)sizeof("_defs.sbin") - 1;
+        if (res.code != 0) return res;
+    }
 
-    res = cfg_arm7_definitions(packer, buf, line);
+    {
+        string buf = string(malloc(len + lengthof("_defs.sbin")), len + lengthof("_defs.sbin"));
 
-error:
-    free(buf.s);
-    return res;
+        memcpy(buf.s, val.s, len);
+        memcpy(buf.s + len, "_defs.sbin", lengthof("_defs.sbin"));
+
+        cfgresult res = cfg_arm7_definitions(packer, buf, line);
+        free(buf.s);
+
+        if (res.code != 0) return res;
+    }
+
+    return configok;
 }
 
 // clang-format off

--- a/source/parse/cfg_arm.c
+++ b/source/parse/cfg_arm.c
@@ -16,6 +16,8 @@
 #include "libs/strings.h"
 #include "libs/vector.h"
 
+#define NEF_EXT_LEN ((long)sizeof(".nef") - 1)
+
 // NOTE: This performs an allocation that may *appear* to be left dangling, but we employ a trick:
 // The first element of the vector points to the beginning of the allocated region, so freeing the
 // first element's filename string will free the entire region.
@@ -123,6 +125,36 @@ static cfgresult cfg_arm9_overlaytable(rompacker *packer, string val, long line)
     return cfg_arm_prepfile(packer, &packer->ovt9, val, line, "arm9", "overlay table");
 }
 
+static cfgresult cfg_arm9_nef(rompacker *packer, string val, long line)
+{
+    varsub(val, packer);
+
+    if (val.len < NEF_EXT_LEN) configerr("nef path length is less than four characters");
+    const string stem = { .s = val.s + val.len - NEF_EXT_LEN, .len = NEF_EXT_LEN };
+    if (!strequ(stem, string(".nef"))) configerr("nef path does not end in .nef");
+
+    long len = val.len - NEF_EXT_LEN;
+
+    string buf = string(malloc(len + sizeof("_defs.sbin") - 1), len + (long)sizeof(".sbin") - 1);
+
+    memcpy(buf.s, val.s, len);
+    memcpy(buf.s + len, ".sbin", sizeof(".sbin") - 1);
+
+    cfgresult res = cfg_arm9_staticbinary(packer, buf, line);
+    if (res.code != 0) { goto error; }
+
+    // in case it clobbers the buffer, copy again.
+    memcpy(buf.s, val.s, len);
+    memcpy(buf.s + len, "_defs.sbin", sizeof("_defs.sbin") - 1);
+    buf.len = len + (long)sizeof("_defs.sbin") - 1;
+
+    res = cfg_arm9_definitions(packer, buf, line);
+
+error:
+    free(buf.s);
+    return res;
+}
+
 static cfgresult cfg_arm7_staticbinary(rompacker *packer, string val, long line)
 {
     return cfg_arm_prepfile(packer, &packer->arm7, val, line, "arm7", "static binary");
@@ -159,16 +191,13 @@ static cfgresult cfg_arm7_nef(rompacker *packer, string val, long line)
 {
     varsub(val, packer);
 
-    if (val.len < 4) configerr("nef path length is less than four characters");
-    else if (memcmp(val.s + val.len - (sizeof(".nef") - 1), ".nef", sizeof(".nef") - 1) != 0)
-        configerr("nef path does not end in .nef");
+    if (val.len < NEF_EXT_LEN) configerr("nef path length is less than four characters");
+    const string stem = { .s = val.s + val.len - NEF_EXT_LEN, .len = NEF_EXT_LEN };
+    if (!strequ(stem, string(".nef"))) configerr("nef path does not end in .nef");
 
-    long len = val.len - ((long)sizeof(".nef") - 1);
+    long len = val.len - NEF_EXT_LEN;
 
-    string buf = {
-        .s   = malloc(len + sizeof("_defs.sbin") - 1),
-        .len = len + (long)sizeof(".sbin") - 1,
-    };
+    string buf = string(malloc(len + sizeof("_defs.sbin") - 1), len + (long)sizeof(".sbin") - 1);
 
     memcpy(buf.s, val.s, len);
     memcpy(buf.s + len, ".sbin", sizeof(".sbin") - 1);
@@ -193,6 +222,7 @@ static const keyvalueparser kvparsers_arm9[] = {
     { .key = string("static-binary"), .parser = cfg_arm9_staticbinary },
     { .key = string("definitions"),   .parser = cfg_arm9_definitions  },
     { .key = string("overlay-table"), .parser = cfg_arm9_overlaytable },
+    { .key = string("nef"),           .parser = cfg_arm9_nef          },
     { .key = stringZ,                 .parser = NULL                  },
 };
 

--- a/source/parse/cfg_arm.c
+++ b/source/parse/cfg_arm.c
@@ -160,7 +160,7 @@ static cfgresult cfg_arm7_nef(rompacker *packer, string val, long line)
     varsub(val, packer);
 
     if (val.len < 4) configerr("nef path length is less than four characters");
-    else if (memcmp(val.s + val.len - sizeof(".nef") + 1, ".nef", sizeof(".nef") - 1) != 0)
+    else if (memcmp(val.s + val.len - (sizeof(".nef") - 1), ".nef", sizeof(".nef") - 1) != 0)
         configerr("nef path does not end in .nef");
 
     long len = val.len - ((long)sizeof(".nef") - 1);
@@ -170,14 +170,14 @@ static cfgresult cfg_arm7_nef(rompacker *packer, string val, long line)
         .len = len + (long)sizeof(".sbin") - 1,
     };
 
-    memcpy(buf.s, val.s, val.len - 4);
+    memcpy(buf.s, val.s, len);
     memcpy(buf.s + len, ".sbin", sizeof(".sbin") - 1);
 
     cfgresult res = cfg_arm7_staticbinary(packer, buf, line);
     if (res.code != 0) { goto error; }
 
     // in case it clobbers the buffer, copy again.
-    memcpy(buf.s, val.s, val.len);
+    memcpy(buf.s, val.s, len);
     memcpy(buf.s + len, "_defs.sbin", sizeof("_defs.sbin") - 1);
     buf.len = len + (long)sizeof("_defs.sbin") - 1;
 

--- a/source/parse/cfg_arm.c
+++ b/source/parse/cfg_arm.c
@@ -158,26 +158,26 @@ static cfgresult cfg_arm7_overlaytable(rompacker *packer, string val, long line)
 static cfgresult cfg_arm7_nef(rompacker *packer, string val, long line)
 {
     varsub(val, packer);
+
     if (val.len < 4) configerr("nef path length is less than four characters");
-    else if (strncmp((char *)val.s + val.len - 4, ".nef", 4)) configerr("nef path does not end in .nef");
-    
+    else if (strncmp((char *)val.s + val.len - 4, ".nef", 4) != 0)
+        configerr("nef path does not end in .nef");
+
     string buf = {
-        .s = malloc(val.len - 4 + sizeof("_defs.sbin")),
-        .len = val.len - 4 + sizeof(".sbin"),
+        .s   = malloc(val.len - 4 + sizeof("_defs.sbin") + 1 + 1),
+        .len = val.len - 4 + (long)sizeof(".sbin"),
     };
 
     memcpy(buf.s, val.s, val.len - 4);
-    memcpy(buf.s + val.len - 4, ".sbin", 5);
+    memcpy((char *)buf.s + val.len - 4, ".sbin", sizeof(".sbin"));
 
     cfgresult res = cfg_arm7_staticbinary(packer, buf, line);
-    if (res.code != 0) {
-        goto error;
-    }
+    if (res.code != 0) { goto error; }
 
     // in case it clobbers the buffer, copy again.
     memcpy(buf.s, val.s, val.len - 4);
-    memcpy(buf.s + val.len - 4, "_defs.sbin", 10);
-    buf.len = val.len - 4 + sizeof("_defs.sbin");
+    memcpy((char *)buf.s + val.len - 4, "_defs.sbin", sizeof("_defs.sbin"));
+    buf.len = val.len - 4 + (long)sizeof("_defs.sbin");
 
     res = cfg_arm7_definitions(packer, buf, line);
 

--- a/source/parse/cfg_arm.c
+++ b/source/parse/cfg_arm.c
@@ -155,6 +155,37 @@ static cfgresult cfg_arm7_overlaytable(rompacker *packer, string val, long line)
     return cfg_arm_prepfile(packer, &packer->ovt7, val, line, "arm7", "overlay table");
 }
 
+static cfgresult cfg_arm7_nef(rompacker *packer, string val, long line)
+{
+    varsub(val, packer);
+    if (val.len < 4) configerr("nef path length is less than four characters")
+    else if (strncmp((char *)val.s + val.len - 4, ".nef", 4)) configerr("nef path does not end in .nef")
+    
+    string buf = {
+        .s = malloc(val.len - 4 + sizeof("_defs.sbin")),
+        .len = val.len - 4 + sizeof(".sbin"),
+    };
+
+    memcpy(buf.s, val.s, val.len - 4);
+    memcpy(buf.s + val.len - 4, ".sbin", 5);
+
+    cfgresult res = cfg_arm7_staticbinary(packer, buf, line);
+    if (res.code != 0) {
+        goto error;
+    }
+
+    // in case it clobbers the buffer, copy again.
+    memcpy(buf.s, val.s, val.len - 4);
+    memcpy(buf.s + val.len - 4, "_defs.sbin", 10);
+    buf.len = val.len - 4 + sizeof("_defs.sbin");
+
+    res = cfg_arm7_definitions(packer, buf, line);
+
+error:
+    free(buf.s);
+    return res;
+}
+
 // clang-format off
 static const keyvalueparser kvparsers_arm9[] = {
     { .key = string("static-binary"), .parser = cfg_arm9_staticbinary },
@@ -167,6 +198,7 @@ static const keyvalueparser kvparsers_arm7[] = {
     { .key = string("static-binary"), .parser = cfg_arm7_staticbinary },
     { .key = string("definitions"),   .parser = cfg_arm7_definitions  },
     { .key = string("overlay-table"), .parser = cfg_arm7_overlaytable },
+    { .key = string("nef"),           .parser = cfg_arm7_nef          },
     { .key = stringZ,                 .parser = NULL                  },
 };
 // clang-format on

--- a/source/parse/cfg_arm.c
+++ b/source/parse/cfg_arm.c
@@ -158,8 +158,8 @@ static cfgresult cfg_arm7_overlaytable(rompacker *packer, string val, long line)
 static cfgresult cfg_arm7_nef(rompacker *packer, string val, long line)
 {
     varsub(val, packer);
-    if (val.len < 4) configerr("nef path length is less than four characters")
-    else if (strncmp((char *)val.s + val.len - 4, ".nef", 4)) configerr("nef path does not end in .nef")
+    if (val.len < 4) configerr("nef path length is less than four characters");
+    else if (strncmp((char *)val.s + val.len - 4, ".nef", 4)) configerr("nef path does not end in .nef");
     
     string buf = {
         .s = malloc(val.len - 4 + sizeof("_defs.sbin")),

--- a/source/parse/cfgparse.h
+++ b/source/parse/cfgparse.h
@@ -11,7 +11,7 @@
 #include "libs/strings.h"
 
 #define configerr(__msg, ...)                                        \
-    {                                                                \
+    do {                                                             \
         cfgresult __res = { .code = E_config_user, .pos = stringZ }; \
         snprintf(                                                    \
             (__res).msg,                                             \
@@ -21,7 +21,7 @@
             ##__VA_ARGS__                                            \
         );                                                           \
         return __res;                                                \
-    }
+    } while (0)
 
 #define configok              \
     (cfgresult)               \


### PR DESCRIPTION
As the title describes, add a `nef` field to the arm7 configuration. The paths to the arm7 and definitions are derived from it by substituting the path ending.

As well, change the filename buffer size from 256 bytes to 4096 bytes.

This PR is in tandem with [one from NitroSDK](https://github.com/ntrtwl/NitroSDK/pull/4)